### PR TITLE
Add dissertation option to class

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ What this repo provides:
 
 Fork the thing. This can conveniently be built with `latexmk`. LaTeX and `latexmk` should be installed and configured separately. Debian-based systems can do this all through `apt`. Alternatively, upload the files to Overleaf and let it magically work.
 
+## Doctoral dissertation mode (experimental)
+
+This documentclass provides a dissertation mode for doctoral candidates. To enable this mode, pass the `dissertation` option to the class declaration:
+
+```latex
+\documentclass[dissertation]{uk_thesis}
+```
+
+At the moment, this mode changes all usages of `Thesis` with `Dissertation` in the front matter. It may do more than that as more differences between the thesis and dissertation formats are uncovered.
+
 ## Contributing
 
 See [this page](CONTRIBUTING.md).

--- a/docs/uk_thesis_interface.md
+++ b/docs/uk_thesis_interface.md
@@ -2,7 +2,17 @@
 
 If it ain't required and you don't want to include it, comment it out rather than providing an empty definition.
 
-## Fields 
+## Options
+
+### Thesis/Dissertation mode
+
+```latex
+\documentclass{uk_thesis}               % implicit thesis mode
+\documentclass[thesis]{uk_thesis}       % explicit thesis mode
+\documentclass[dissertation]{uk_thesis} % dissertation mode
+```
+
+## Fields
 
 ### Title (required)
 
@@ -59,7 +69,9 @@ If you want to align the co-director and director's names, you can use
 ```
 ### College (required)
 
+```latex
 \college{Engineering}
+```
 
 ### Submission date (required)
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -1,4 +1,4 @@
-\documentclass{uk_thesis}
+\documentclass{uk_thesis} % use the dissertation option to change usage of "Thesis" to "Dissertation" in the front matter (e.g. \documentclass[dissertation]{uk_thesis})
 
 % ~~~ PACKAGES ~~~
     \usepackage{diagbox} % for the corners of tables

--- a/uk_thesis.cls
+++ b/uk_thesis.cls
@@ -8,6 +8,21 @@
   bibliography=totoc
 ]{scrbook}
 
+% ~~~ CLASS OPTIONS ~~~
+
+% Set document type (Thesis/Dissertation). Arg should be in Camel case.
+\newcommand{\doctype}[1]{
+    \renewcommand{\@DocType}{#1}
+    \renewcommand{\@DOCTYPE}{\expandafter\MakeUppercase\expandafter{#1}}
+    \renewcommand{\@doctype}{\expandafter\MakeLowercase\expandafter{#1}}
+}
+\newcommand{\@doctype}{thesis} % lower case doctype
+\newcommand{\@DOCTYPE}{THESIS} % upper case doctype
+\newcommand{\@DocType}{Thesis} % camel case doctype
+\DeclareOption{thesis}{\doctype{Thesis}} % set to thesis mode
+\DeclareOption{dissertation}{\doctype{Dissertation}} % set to dissertation mode
+\ProcessOptions*\relax
+
 % ~~~ PACKAGES NECESSARY ~~~
 
 \RequirePackage[
@@ -94,9 +109,9 @@
   \end{textblock*}
   \begin{textblock*}{\textwidth}(1.5in, 4in)
     \begin{center}
-      \@titlepagerule{THESIS}\\
+      \@titlepagerule{\@DOCTYPE}\\
       \@titlepagerule{} % TODO: figure out the spacing on this.
-      A thesis submitted in partial fulfillment of the\\
+      A \@doctype{} submitted in partial fulfillment of the\\
       requirements for the degree of \@degree{}\\
       in the College of \@college\\
       at the University of Kentucky\\
@@ -142,7 +157,7 @@
   \thispagestyle{plain}
   \begin{textblock*}{\textwidth}(1.5in, 2.5in)
   \begin{center}
-    ABSTRACT OF THESIS
+    ABSTRACT OF \@DOCTYPE
   \end{center}
   \end{textblock*}
   \begin{textblock*}{\textwidth}(1.5in, 3.5in)
@@ -181,10 +196,10 @@
   \begin{textblock*}{\@signaturewidth}(\paperwidth - \@signaturewidth - 1in,7in)
     \centering
     \ifdefempty{\@codirector}{
-      \noindent\@signature{Director of Thesis}{\@director} \\
+      \noindent\@signature{Director of \@DocType}{\@director} \\
     }{
-      \noindent\@signature{Co-Director of Thesis}{\@director} \\
-      \noindent\@signature{Co-Director of Thesis}{\@codirector} \\
+      \noindent\@signature{Co-Director of \@DocType}{\@director} \\
+      \noindent\@signature{Co-Director of \@DocType}{\@codirector} \\
     }
     \noindent\@signature{Director of Graduate Studies}{\@dgs} \\
     \noindent\@signature{Date}{\@submissionmonth/\@submissionday/\@submissionyear} \\
@@ -286,4 +301,4 @@
 % make chapter TOC entries uppercase. Also prevent hyperref complaining about the MakeUppercase macro.
 \renewcommand\addchaptertocentry[2]{%
   \addtocentrydefault{chapter}{#1}{\texorpdfstring{\MakeUppercase{#2}}{#2}}%
-} 
+}


### PR DESCRIPTION
Adds a `Dissertation` option to the class declaration which replaces all uses of "Thesis" with "Dissertation" in the front matter:

```latex
\documentclass[dissertation]{uk_thesis}
```

Progress on #2.
