### PR TITLE
Format long abstracts properly

### DIFF
--- a/uk_thesis.cls
+++ b/uk_thesis.cls
@@ -185,9 +185,12 @@
       \vspace*{1mm}\\
       KEYWORDS: \@keywords
     }
+    \par
     \vfill
     \hfill
     \raggedleft
+    \par
+    \vspace*{\fill}
     \parbox[c]{\@signaturewidth}{
       \centering
       \@signature{}{\@author}

--- a/uk_thesis.cls
+++ b/uk_thesis.cls
@@ -156,34 +156,46 @@
   \pagebreak
 
 }
-
+  
 \newcommand{\@abstractpage} {
   \pdfbookmark[0]{Abstract}{abstract}
-  \vspace*{0mm}
-  \thispagestyle{plain}
-  \begin{textblock*}{\textwidth}(1.5in, 2.5in)
-  \begin{center}
-    ABSTRACT OF \@DOCTYPE
-  \end{center}
-  \end{textblock*}
-  \begin{textblock*}{\textwidth}(1.5in, 3.5in)
-  \begin{center}
-    \MakeUppercase{\@title}
-  \end{center}
-  \end{textblock*}
-  \begin{textblock*}{\textwidth}(1.5in, 4.5in)
+  {
+    \thispagestyle{plain}
+    \setlength{\topskip}{0mm}
+    \nointerlineskip
+    \setlength{\parskip}{0pt}
+    \setlength{\rightskip}{0pt}
+    \vspace*{2.5in}
+    \begin{textblock*}{\textwidth}(1.5in, 2.5in)
+      \begin{center}
+        ABSTRACT OF \@DOCTYPE
+      \end{center}
+    \end{textblock*}
+    \@topsepadd \topsep
+    \advance\@topsepadd \partopsep
+    \setlength{\@topsep}{1\@topsepadd}
+    {
+      \centering 
+      \addvspace\@topsep
+      \MakeUppercase{\@title} \par
+    }
+    \vspace*{0.45in} 
     \@abstract\\
     \ifdefempty{\@keywords}{}{
       \vspace*{1mm}\\
       KEYWORDS: \@keywords
     }
-  \end{textblock*}
-  \begin{textblock*}{\@signaturewidth}(\paperwidth - \@signaturewidth - 1in,8in)
-    \centering
-    \noindent\@signature{}{\@author}
-    \noindent\@signature{Date}{\@submissionmonth/\@submissionday/\@submissionyear} \\
-  \end{textblock*}
-  \pagebreak
+    \vfill
+    \hfill
+    \raggedleft
+    \parbox[c]{\@signaturewidth}{
+      \centering
+      \@signature{}{\@author}
+      \@signature{Date}{\@submissionmonth/\@submissionday/\@submissionyear}
+    }
+    \vspace*{1in} \par
+    \pagebreak
+  }
 }
 
 


### PR DESCRIPTION
This pull request is to fix #13 , which describes a problem where long abstracts can cause texts to overflow the page and overlap signatures. The changes in this pull request should cause the template to instead split long abstracts across multiple pages.

I've attached [the output](https://github.com/user-attachments/files/22651810/diff.pdf) of [`diff-pdf`](https://github.com/vslavik/diff-pdf) for PDFs produced from the example thesis before and after the changes. The new version is not exactly the same as the original, but much of the document, including the main body of the document, is unchanged. 

Although the "Abstract of Thesis" text and the title are in the same position, the abstract itself is slightly lower in the new version. The `\vspace*` at https://github.com/actapia/uk_thesis/blob/95a52eec7b91c65b1088ace7d6d575b78c24ad33/uk_thesis.cls#L182 could probably be adjusted to make it exactly the same, but I didn't like the idea of using an apparently very arbitrary number of inches for the spacing there.

The signatures are placed so that there is roughly 2 inches from the bottom of the signature to the bottom of the page, as suggested by [this guide](https://web.archive.org/web/20250116003640/https://gradschool.uky.edu/sites/gradschool.uky.edu/files/Documents/ThesisDissertationPrep/Dissertation_Abstract_Example.pdf).

The Dedication page text is also slightly higher in the new version. Admittedly, I don't quite understand what ultimately causes that, but I figure it's probably an acceptably small deviation.