### PR TITLE
Use italics for default \emph

### DIFF
--- a/uk_thesis.cls
+++ b/uk_thesis.cls
@@ -36,7 +36,7 @@
 \RequirePackage{anyfontsize} % fixes some weirdness with choosing font size
 \RequirePackage[absolute, overlay]{textpos} % for placing text at absolute locations with textbox* environment
 \RequirePackage{etoolbox} % Tools for working with LaTeX macros (see ifdefempty)
-\RequirePackage{ulem} % For horizontal rules on intro pages
+\RequirePackage[normalem]{ulem} % For horizontal rules on intro pages
 \RequirePackage{scrlayer-scrpage} % For configuring headers and footers
 \RequirePackage{bookmark} % to add bookmarks to the PDF output, university requirement
 


### PR DESCRIPTION
This change addresses #16 ; It causes `\emph` to italicize by default by adding the `normalem` option to the `ulem` package.