### PR TITLE
Double space acknowledgements

### DIFF
--- a/uk_thesis.cls
+++ b/uk_thesis.cls
@@ -229,7 +229,9 @@
 \newcommand{\acknowledgementspage}{
   \ifdefempty{\@acknowledgements}{}{
     \chapter{Acknowledgements}
-    \@acknowledgements
+    \begin{doublespace}
+      \@acknowledgements
+    \end{doublespace}
   }
 }
 


### PR DESCRIPTION
This change double-spaces the Acknowledgements page by default, matching the default body spacing This ameliorates #18 .